### PR TITLE
resolve #1 resourceHacker parameters

### DIFF
--- a/duckietv-builder
+++ b/duckietv-builder
@@ -24,7 +24,7 @@ if (!which('git')) {
 
 
 program
-    .version('1.0.7')
+    .version('1.0.8')
     .option('-v, --verbose', 'increase verbosity')
     .command('tag-release', 'create a new (nightly) tag and push it to the repository')
     .command('prepare', 'prepare (nightly) builds for [platforms]')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "duckietv-builder",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "description": "A new way to build duckietv",
     "main": "duckietv-builder",
     "repository": "https://github.com/DuckieTV/duckietv-builder.git",

--- a/platforms/windows.js
+++ b/platforms/windows.js
@@ -74,10 +74,10 @@ module.exports = {
                 if (process.platform != 'win32') {
                     RESHACKER_PATH = 'wine ' + RESHACKER_PATH;
                 }
-                exec(RESHACKER_PATH + ' -addoverwrite "DuckieTV.exe","DuckieTV.exe","img/favicon-inverted.ico",ICONGROUP,IDR_ALT_ICON,0');
-                exec(RESHACKER_PATH + ' -addoverwrite "DuckieTV.exe","DuckieTV.exe","img/favicon.ico",ICONGROUP,IDR_MAINFRAME,1033');
-                exec(RESHACKER_PATH + ' -addoverwrite "DuckieTV.exe","DuckieTV.exe","img/favicon.ico",ICONGROUP,IDR_X001_APP_LIST,1033');
-                exec(RESHACKER_PATH + ' -addoverwrite "DuckieTV.exe", "DuckieTV.exe", "' + __dirname + '/windows/fileinfo.res", VERSIONINFO, 1, 1033');
+                exec(RESHACKER_PATH + ' -open "' + ARCH_BUILD_DIR + '/DuckieTV.exe" -save "' + ARCH_BUILD_DIR + '/DuckieTV.exe" -action addoverwrite -resource "' + ARCH_BUILD_DIR + '/img/favicon-inverted.ico" -mask ICONGROUP, IDR_ALT_ICON, 0 -log "' + BUILD_DIR + '/RHlog1.txt"');
+                exec(RESHACKER_PATH + ' -open "' + ARCH_BUILD_DIR + '/DuckieTV.exe" -save "' + ARCH_BUILD_DIR + '/DuckieTV.exe" -action addoverwrite -resource "' + ARCH_BUILD_DIR + '/img/favicon.ico" -mask ICONGROUP, IDR_MAINFRAME, 1033 -log "' + BUILD_DIR + '/RHlog2.txt"');
+                exec(RESHACKER_PATH + ' -open "' + ARCH_BUILD_DIR + '/DuckieTV.exe" -save "' + ARCH_BUILD_DIR + '/DuckieTV.exe" -action addoverwrite -resource "' + ARCH_BUILD_DIR + '/img/favicon.ico" -mask ICONGROUP, IDR_X001_APP_LIST, 1033 -log "' + BUILD_DIR + '/RHlog3.txt"');
+                exec(RESHACKER_PATH + ' -open "' + ARCH_BUILD_DIR + '/DuckieTV.exe" -save "' + ARCH_BUILD_DIR + '/DuckieTV.exe" -action addoverwrite -resource "' + __dirname + '/windows/fileinfo.res" -mask VERSIONINFO, 1, 1033 -log "' + BUILD_DIR + '/RHlog4.txt"');
                 exec("makensis app.nsi");
                 mv(buildUtils.buildFileName(INSTALLER_FILENAME, arch), '..');
                 popd();


### PR DESCRIPTION
add full path to all files resourceHacker is expected to use, including a log.
Parameters conform to resourceHacker 4.5.30 http://angusj.com/resourcehacker/
Tested on Ubuntu 16.10 and Windows 7 with the following:
duckietv-builder make-binaries --nightly --platform windows